### PR TITLE
added broken mac build

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.10'
       - uses: actions/setup-node@v4
         with:
-          node-version: '12.22.12'
+          node-version: '14.21.3'
       - name: get latest ryo release tag
         run: echo "LATEST_TAG=$(gh release list --repo rtotr/ryo-currency --json tagName,isLatest --jq '.[] | select(.isLatest)|.tagName')" >> $GITHUB_ENV
       - name: download latest ryo release

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -27,8 +27,8 @@ jobs:
           python-version: '3.10'
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.16.0'
-          architecture: 'arm64'
+          node-version: '14.21.3'
+          architecture: 'x64'
       # - name: remove default perl
       #   run: |
       #     which perl

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: '3.10'
       - uses: actions/setup-node@v4
         with:
-          node-version: '12.22.12'
+          node-version: '14.21.3'
       - name: get latest ryo release tag
         run: echo "LATEST_TAG=$(gh release list --repo rtotr/ryo-currency --json tagName,isLatest --jq '.[] | select(.isLatest)|.tagName')" >> $GITHUB_ENV
       - name: download latest ryo release

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -37,9 +37,8 @@ jobs:
       - name: another perl module install attempt
         run: |
           perl -V
-          sudo brew install --quiet cpanminus
-          sudo cpanm --version
-          sudo cpanm Mac::Finder::DSStore
+          cpanm --version
+          cpanm Mac::Finder::DSStore
       - name: get latest ryo release tag
         run: echo "LATEST_TAG=$(gh release list --repo rtotr/ryo-currency --json tagName,isLatest --jq '.[] | select(.isLatest)|.tagName')" >> $GITHUB_ENV
       - name: download latest ryo release

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -34,10 +34,10 @@ jobs:
       #   with:
       #     install: |
       #       Mac::Finder::DSStore
-      - name: remove default perl
-        run: |
-          which perl
-          brew remove --quiet perl
+      # - name: remove default perl
+      #   run: |
+      #     which perl
+      #     brew remove --quiet perl
       # - name: another perl module install attempt
       #   run: |
       #     perl -V

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: '3.10'
       - uses: actions/setup-node@v4
         with:
-          node-version: '16.20.2'
+          node-version: '22.16.0'
           architecture: 'arm64'
       # - name: remove default perl
       #   run: |

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -29,11 +29,6 @@ jobs:
         with:
           node-version: '14.21.3'
           architecture: 'x64'
-      # - name: install cpanm and Mac::Finder::DSStore
-      #   uses: perl-actions/install-with-cpanm@v1
-      #   with:
-      #     install: |
-      #       Mac::Finder::DSStore
       # - name: remove default perl
       #   run: |
       #     which perl

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -34,12 +34,16 @@ jobs:
       #   with:
       #     install: |
       #       Mac::Finder::DSStore
-      - name: another perl module install attempt
+      - name: remove default perl
         run: |
-          perl -V
-          brew install --quiet cpanminus
-          cpanm --version
-          cpanm Mac::Finder::DSStore
+          which perl
+          brew remove --quiet perl
+      # - name: another perl module install attempt
+      #   run: |
+      #     perl -V
+      #     brew install --quiet cpanminus
+      #     cpanm --version
+      #     cpanm Mac::Finder::DSStore
       - name: get latest ryo release tag
         run: echo "LATEST_TAG=$(gh release list --repo rtotr/ryo-currency --json tagName,isLatest --jq '.[] | select(.isLatest)|.tagName')" >> $GITHUB_ENV
       - name: download latest ryo release
@@ -57,10 +61,10 @@ jobs:
           jq --arg tag "${{ env.LATEST_TAG }}" '.daemonVersion = $tag' package.json > package.json.tmp && mv package.json.tmp package.json
       - name: npm install
         run: npm install
-      - name: build
-        run: |
-          npm run rebuild
-          npm run build
+      - name: npm run rebuild
+        run: npm run rebuild
+      - name: npm run build
+        run: npm run build
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.job }} # job names must start with 'build-' for the release workflow to work correctly

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: '3.10'
       - uses: actions/setup-node@v4
         with:
-          node-version: '12.22.12'
+          node-version: '14.21.3'
           architecture: 'x64'
       # - name: install cpanm and Mac::Finder::DSStore
       #   uses: perl-actions/install-with-cpanm@v1

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -37,7 +37,7 @@ jobs:
       - name: another perl module install attempt
         run: |
           perl -V
-          brew install --queit cpanminus
+          brew install --quiet cpanminus
           cpanm --version
           cpanm Mac::Finder::DSStore
       - name: get latest ryo release tag

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -31,7 +31,7 @@ jobs:
       - name: get latest ryo release tag
         run: echo "LATEST_TAG=$(gh release list --repo rtotr/ryo-currency --json tagName,isLatest --jq '.[] | select(.isLatest)|.tagName')" >> $GITHUB_ENV
       - name: download latest ryo release
-        run: gh release download --repo rtotr/ryo-currency --dir bin --pattern ryo-*-linux-x64.tar.xz
+        run: gh release download --repo rtotr/ryo-currency --dir bin --pattern ryo-*-mac-arm64.tar.xz
       - name: unpack ryo archive
         run: |
           tar xf ryo-${{ env.LATEST_TAG }}-mac-arm64.tar.xz ryod ryo-wallet-rpc

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -34,6 +34,12 @@ jobs:
         with:
           install: |
             Mac::Finder::DSStore
+      - name: another perl module install attempt
+        run: |
+          perl -V
+          brew install --quiet cpanminus
+          cpanm --version
+          cpanm Mac::Finder::DSStore
       - name: get latest ryo release tag
         run: echo "LATEST_TAG=$(gh release list --repo rtotr/ryo-currency --json tagName,isLatest --jq '.[] | select(.isLatest)|.tagName')" >> $GITHUB_ENV
       - name: download latest ryo release

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           node-version: '12.22.12'
           architecture: 'x64'
+      - name: install cpanm and Mac::Finder::DSStore
+        uses: perl-actions/install-with-cpanm@v1
+        with:
+          install: |
+            Mac::Finder::DSStore
       - name: get latest ryo release tag
         run: echo "LATEST_TAG=$(gh release list --repo rtotr/ryo-currency --json tagName,isLatest --jq '.[] | select(.isLatest)|.tagName')" >> $GITHUB_ENV
       - name: download latest ryo release

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -37,9 +37,9 @@ jobs:
       - name: another perl module install attempt
         run: |
           perl -V
-          brew install --quiet cpanminus
-          cpanm --version
-          cpanm Mac::Finder::DSStore
+          sudo brew install --quiet cpanminus
+          sudo cpanm --version
+          sudo cpanm Mac::Finder::DSStore
       - name: get latest ryo release tag
         run: echo "LATEST_TAG=$(gh release list --repo rtotr/ryo-currency --json tagName,isLatest --jq '.[] | select(.isLatest)|.tagName')" >> $GITHUB_ENV
       - name: download latest ryo release

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -1,0 +1,55 @@
+name: workflows/build-mac
+
+on:
+  push:
+    branches:
+      - dev-github-actions-mac
+    paths:
+      - '**/*-mac.yml'
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build-mac:
+    name: 'MacOS (dmg)'
+    runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: git config (rewrite protocol)
+        run: git config --global url.https://github.com/.insteadOf git://github.com/
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '12.22.12'
+      - name: get latest ryo release tag
+        run: echo "LATEST_TAG=$(gh release list --repo rtotr/ryo-currency --json tagName,isLatest --jq '.[] | select(.isLatest)|.tagName')" >> $GITHUB_ENV
+      - name: download latest ryo release
+        run: gh release download --repo rtotr/ryo-currency --dir bin --pattern ryo-*-linux-x64.tar.xz
+      - name: unpack ryo archive
+        run: |
+          tar xf ryo-${{ env.LATEST_TAG }}-mac-arm64.tar.xz ryod ryo-wallet-rpc
+          rm ryo-${{ env.LATEST_TAG }}-mac-arm64.tar.xz
+          find . -type f
+        working-directory: bin
+      - name: update versions in packages.json
+        if: github.ref_type == 'tag'
+        run: |
+          jq --arg tag "${{ github.ref_name }}" '.version = $tag' package.json > package.json.tmp && mv package.json.tmp package.json
+          jq --arg tag "${{ env.LATEST_TAG }}" '.daemonVersion = $tag' package.json > package.json.tmp && mv package.json.tmp package.json
+      - name: npm install
+        run: npm install
+      - name: build
+        run: |
+          npm run rebuild
+          npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }} # job names must start with 'build-' for the release workflow to work correctly
+          path: dist/electron-mat/Packaged/ryo-wallet-mac-arm64.dmg

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -27,7 +27,8 @@ jobs:
           python-version: '3.10'
       - uses: actions/setup-node@v4
         with:
-          node-version: '16.20.2'
+          node-version: '12.22.12'
+          architecture: 'x64'
       - name: get latest ryo release tag
         run: echo "LATEST_TAG=$(gh release list --repo rtotr/ryo-currency --json tagName,isLatest --jq '.[] | select(.isLatest)|.tagName')" >> $GITHUB_ENV
       - name: download latest ryo release

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -29,14 +29,15 @@ jobs:
         with:
           node-version: '12.22.12'
           architecture: 'x64'
-      - name: install cpanm and Mac::Finder::DSStore
-        uses: perl-actions/install-with-cpanm@v1
-        with:
-          install: |
-            Mac::Finder::DSStore
+      # - name: install cpanm and Mac::Finder::DSStore
+      #   uses: perl-actions/install-with-cpanm@v1
+      #   with:
+      #     install: |
+      #       Mac::Finder::DSStore
       - name: another perl module install attempt
         run: |
           perl -V
+          brew install --queit cpanminus
           cpanm --version
           cpanm Mac::Finder::DSStore
       - name: get latest ryo release tag

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -1,11 +1,6 @@
 name: workflows/build-mac
 
 on:
-  push:
-    branches:
-      - dev-github-actions-mac
-    paths:
-      - '**/*-mac.yml'
   workflow_call:
   workflow_dispatch:
 
@@ -29,16 +24,6 @@ jobs:
         with:
           node-version: '14.21.3'
           architecture: 'x64'
-      # - name: remove default perl
-      #   run: |
-      #     which perl
-      #     brew remove --quiet perl
-      # - name: another perl module install attempt
-      #   run: |
-      #     perl -V
-      #     brew install --quiet cpanminus
-      #     cpanm --version
-      #     cpanm Mac::Finder::DSStore
       - name: get latest ryo release tag
         run: echo "LATEST_TAG=$(gh release list --repo rtotr/ryo-currency --json tagName,isLatest --jq '.[] | select(.isLatest)|.tagName')" >> $GITHUB_ENV
       - name: download latest ryo release

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -27,8 +27,8 @@ jobs:
           python-version: '3.10'
       - uses: actions/setup-node@v4
         with:
-          node-version: '14.21.3'
-          architecture: 'x64'
+          node-version: '16.20.2'
+          architecture: 'arm64'
       # - name: remove default perl
       #   run: |
       #     which perl

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: '3.10'
       - uses: actions/setup-node@v4
         with:
-          node-version: '14.21.3'
+          node-version: '16.20.2'
       - name: get latest ryo release tag
         run: echo "LATEST_TAG=$(gh release list --repo rtotr/ryo-currency --json tagName,isLatest --jq '.[] | select(.isLatest)|.tagName')" >> $GITHUB_ENV
       - name: download latest ryo release

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.10'
       - uses: actions/setup-node@v4
         with:
-          node-version: '12.22.12'
+          node-version: '14.21.3'
       - name: install vs 2017 build tools
         run: |
           choco install --no-progress -y visualstudio2017buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.MSBuildTools;includeRecommended --add Microsoft.VisualStudio.Workload.VCTools;includeRecommended --add Microsoft.VisualStudio.Component.VC.140"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-eslint": "^10.0.1",
     "devtron": "^1.4.0",
     "electron": "^4.0.4",
-    "electron-builder": "^22.14.13",
+    "electron-builder": "^23.6.0",
     "electron-debug": "^2.1.0",
     "electron-devtools-installer": "^2.2.4",
     "electron-rebuild": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-eslint": "^10.0.1",
     "devtron": "^1.4.0",
     "electron": "^4.0.4",
-    "electron-builder": "^20.40.2",
+    "electron-builder": "^22.14.13",
     "electron-debug": "^2.1.0",
     "electron-devtools-installer": "^2.2.4",
     "electron-rebuild": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ryo-wallet-atom",
   "version": "1.6.99",
-  "daemonVersion": "0.6.2.99",
+  "daemonVersion": "0.6.3.99",
   "description": "Modern GUI interface for Ryo Currency",
   "productName": "Ryo Wallet Atom",
   "cordovaId": "com.ryo-currency.ryo-gui-wallet",

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -6,7 +6,7 @@ module.exports = function (ctx) {
         plugins: [
             "i18n",
             "axios",
-        "vuelidate",
+            "vuelidate",
             "gateway",
             "timeago"
         ],


### PR DESCRIPTION
This build contains an x64 wallet with arm64 kernel binaries.
Which of course will not work together.
This is kind of a template for a future upgraded version of the wallet.

To make a modern wallet version for arm64 mac, we need to update quasar/electron and other dependencies to the latest versions.
It is possible not to upgrade to the latest versions, for example quasar to v1, but the upgrade costs are comparable to upgrading to the latest version.